### PR TITLE
Record the local-tool decision (#36)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,13 +118,24 @@ npx tsc -b           # 型チェック
 
 ## 既知の設計判断と制約
 
-### API が Vite プラグインに同居している
+### ローカルツールとして固める（決定済み）
 
-`npm run build` した `dist/` は**閲覧専用**で、調査・翻訳・PDF出力・削除は動かない。
-ローカルツールとして固めるか `server/` を独立プロセスに切り出すかは
-[#36](https://github.com/onsoku/WorldDashboard/issues/36) で未決。
-[#38](https://github.com/onsoku/WorldDashboard/issues/38)（ジョブ制御）と
-[#41](https://github.com/onsoku/WorldDashboard/issues/41)（SSE）の実装方針はこの決定に依存する。
+**このプロジェクトはローカルツールである。製品化しない**
+（[#36](https://github.com/onsoku/WorldDashboard/issues/36) で決定）。
+
+API は Vite の `configureServer` プラグインに同居させたままにする。
+`npm run build` した `dist/` は既存トピックの**閲覧専用**で、
+調査・翻訳・PDF出力・削除は `npm run dev` でしか動かない。これは制約ではなく仕様。
+
+したがって:
+
+- `server/` を Express / Hono の独立プロセスに切り出す提案はしない
+- 認証・マルチユーザー・リモートのデータ保存先は考慮しない。単一ユーザーのローカル前提
+- 新機能は dev サーバ内で完結する形で設計する。
+  [#38](https://github.com/onsoku/WorldDashboard/issues/38)（ジョブ制御）は
+  in-process のジョブレジストリで、
+  [#41](https://github.com/onsoku/WorldDashboard/issues/41)（SSE）は
+  同じ Vite middleware で実装する
 
 ### JSON 修復は「開いた構造を閉じる」方式
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ npm run dev
 
 Open http://localhost:5173
 
+> **World Dashboard is a local tool.** The research API lives inside the Vite dev server (`server/research-api.ts`), so research, translation, PDF export, and deletion require `npm run dev`. `npm run build` produces a **read-only** viewer of the topics you already have — it cannot create new ones.
+
 ## Usage
 
 1. Click **"+ New"** in the sidebar

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -54,6 +54,8 @@ npm run dev
 
 Abre http://localhost:5173 en tu navegador
 
+> **World Dashboard es una herramienta local.** La API de investigacion vive dentro del servidor de desarrollo de Vite (`server/research-api.ts`), por lo que investigar, traducir, exportar a PDF y eliminar requieren `npm run dev`. `npm run build` genera un visor de **solo lectura** de los temas existentes; no puede crear nuevos.
+
 ## Uso
 
 1. Haz clic en **"+ Nuevo"** en la barra lateral

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -54,6 +54,8 @@ npm run dev
 
 Ouvrez http://localhost:5173 dans votre navigateur
 
+> **World Dashboard est un outil local.** L'API de recherche est integree au serveur de developpement Vite (`server/research-api.ts`) : la recherche, la traduction, l'export PDF et la suppression necessitent `npm run dev`. `npm run build` produit une visionneuse en **lecture seule** des sujets existants et ne permet pas d'en creer de nouveaux.
+
 ## Utilisation
 
 1. Cliquez sur **"+ Nouveau"** dans la barre laterale

--- a/docs/README.it.md
+++ b/docs/README.it.md
@@ -54,6 +54,8 @@ npm run dev
 
 Apri http://localhost:5173 nel browser
 
+> **World Dashboard e uno strumento locale.** L'API di ricerca vive dentro il server di sviluppo Vite (`server/research-api.ts`), quindi ricerca, traduzione, esportazione PDF ed eliminazione richiedono `npm run dev`. `npm run build` produce un visualizzatore di **sola lettura** degli argomenti esistenti; non puo crearne di nuovi.
+
 ## Utilizzo
 
 1. Clicca **"+ Nuovo"** nella barra laterale

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -58,6 +58,8 @@ npm run dev
 
 ブラウザで http://localhost:5173 を開く
 
+> **World Dashboard はローカルツールです。** 調査 API は Vite の dev サーバ内 (`server/research-api.ts`) にあるため、調査・翻訳・PDF出力・削除は `npm run dev` でのみ動作します。`npm run build` で生成される `dist/` は既存トピックの**閲覧専用**で、新規作成はできません。
+
 ## 使い方
 
 1. サイドバーの **「+ 新規」** をクリック

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -54,6 +54,8 @@ npm run dev
 
 在浏览器中打开 http://localhost:5173
 
+> **World Dashboard 是本地工具。** 研究 API 位于 Vite 开发服务器内部（`server/research-api.ts`），因此研究、翻译、PDF 导出和删除仅在 `npm run dev` 下可用。`npm run build` 生成的 `dist/` 仅供**浏览**已有主题，无法创建新主题。
+
 ## 使用方法
 
 1. 点击侧栏的 **"+ 新建"**


### PR DESCRIPTION
Closes #36

選択肢 (a)「個人ローカルツールと割り切る」で決定。

## 決定

API は Vite の `configureServer` プラグインに同居させたままにする。`dist/` は既存トピックの閲覧専用で、調査・翻訳・PDF出力・削除は `npm run dev` でしか動かない — これは制約ではなく仕様として扱う。

派生する方針:

- `server/` を Express / Hono の独立プロセスに切り出す提案はしない
- 認証・マルチユーザー・リモートのデータ保存先は考慮しない（単一ユーザーのローカル前提）
- #38（ジョブ制御）は in-process のジョブレジストリ、#41（SSE）は同じ Vite middleware で実装する

## 変更

- `CLAUDE.md`: 「未決」節を決定内容に差し替え。#38 / #41 の実装方針もここで確定させた
- README 6言語（en / ja / zh / es / it / fr）: セットアップ直後に注記を追加。`npm run dev` が必要であることを最初に読ませる

`dist/` はリポジトリ側の変更不要。すでに gitignore 済みで追跡もされていなかった（Issue 起票時の前提が古かった）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
