### PR TITLE
Let the server place data files so a slug collision cannot destroy a topic (#42)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,9 @@ SESSIONS/
 # Server-side observability + persistence (issues #24/#25/#26)
 .claude/logs/
 .claude/jobs/
+
+# Copies of topics taken before an intentional overwrite (issue #42)
+.claude/trash/
+
+# Per-job directory the CLI writes into before the server places the file (#42)
+.staging/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,29 @@ slug からファイルパスを組み立てる箇所を新設する場合も同
 正規表現による除去に戻してはいけない。属性付きの `<script >` や
 `<use href="data:...">`、`<animate onbegin=...>` を取りこぼす（[#34](https://github.com/onsoku/WorldDashboard/issues/34)）。
 
-### 5. ジョブが 'running' のままサーバが落ちたら error に倒す
+### 5. CLI は `public/data` に直接書かない。配置はサーバが行う
+
+CLI の出力先はジョブ専用の `.staging/{jobId}/` で、`public/data/` へ移すのは
+`placeJobOutput()`（`server/research-api.ts`）だけ。
+`server/data-placement.ts` が配置と衝突判定を担当する。
+
+以前は CLI が `public/data/{slug}.json` を直接書いていたため、新規調査が既存 slug に
+当たると警告もバックアップもなく上書きされた（[#42](https://github.com/onsoku/WorldDashboard/issues/42)。
+実際に WebAssembly 辞典を1件失っている）。**書かれてから気付いても手遅れ**なので、
+検出ではなく配置の主導権をサーバに移すことで解決している。
+
+衝突ポリシー:
+
+- 新規調査 (`mode: research`) — 既存ファイルには触らない。空いている `{slug}-2` に置き、
+  `meta.slug` もそれに合わせて書き換える。`job.slug_collision` を warn ログに出す
+- 更新 / 翻訳 — slug はジョブが所有しているので上書きしてよい。ただし直前に
+  `.claude/trash/{slug}-{timestamp}.json` へ退避する
+- パースできない JSON も配置する。修復 UI は `public/data` にあるファイルしか触れない
+
+**ステージングを `.claude/` 配下に置いてはいけない。** Claude Code が sensitive file として
+書き込みを拒否し、ジョブがターン上限まで無駄にリトライする。
+
+### 6. ジョブが 'running' のままサーバが落ちたら error に倒す
 
 `server/job-store.ts` の `loadAllJobs()` が起動時に変換する。
 サブプロセスは既に消えているので、実行中として復元してはいけない
@@ -84,6 +106,11 @@ slug からファイルパスを組み立てる箇所を新設する場合も同
 | `cli.wrote_data` | CLI がデータファイルを書いた |
 | `cli.wrote_index` | **不変条件1の違反。** プロンプトが効いていない |
 | `cli.result_error` / `cli.stderr` / `cli.spawn_error` | CLI 側の失敗 |
+| `cli.wrote_outside_staging` | **不変条件5の違反。** ステージング外に書いている |
+| `job.slug_collision` | 新規調査の slug が既存と衝突し、別名で保存した |
+| `job.backup_before_overwrite` | 更新・翻訳の上書き前に `.claude/trash/` へ退避した |
+| `job.no_staged_output` | ステージングに何も無い。Write が拒否された可能性 |
+| `job.place_failed` | 配置に失敗（slug が不正など） |
 | `index.update` / `index.write` / `index.read_failed` | index.json の更新 |
 | `job.restored` / `job.restored_as_interrupted` | 起動時のジョブ復元 |
 | `json.auto_repaired` / `json.unrepairable` | 生成 JSON の修復結果 |
@@ -154,12 +181,6 @@ API は Vite の `configureServer` プラグインに同居させたままにす
 UI は `repair.truncated` で警告する。自動修復（conservative）は従来どおり
 切り詰めに触らない。戻すときは `json-repair.test.ts` の truncation 10形状を見ること。
 
-### slug 衝突で既存辞典が消える
-
-新規調査 (`mode: research`) が既存 slug に当たると、警告もバックアップもなく上書きされ、
-`versions` の履歴も失われる（[#42](https://github.com/onsoku/WorldDashboard/issues/42)）。
-**検証目的でジョブを投入する前に、必ず `index.json` の既存 slug を確認すること。**
-
 ### effect 内での setState
 
 `react-hooks/set-state-in-effect` を5箇所で `eslint-disable` している。
@@ -173,9 +194,12 @@ UI は `repair.truncated` で警告する。自動修復（conservative）は従
 .claude/logs/server.jsonl         # 構造化ログ (gitignore)
 .claude/jobs/*.json               # ジョブ永続化 (gitignore)
 .claude/tmp/prompt-*.txt          # CLI へ渡すプロンプト (gitignore、掃除は #32)
+.claude/trash/                    # 上書き前の退避コピー (gitignore)
+.staging/{jobId}/                 # CLI の出力先。配置後に削除 (gitignore)
 server/
   research-api.ts                 # Vite プラグイン本体。全 API エンドポイント
   index-writer.ts                 # index.json の唯一の書き手 (mutex)
+  data-placement.ts               # ステージング → public/data の配置と衝突判定
   job-store.ts                    # ジョブの永続化と復元
   job-logger.ts                   # 構造化ログ
   json-repair.ts                  # 生成 JSON の検証・修復

--- a/server/data-placement.test.ts
+++ b/server/data-placement.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, readdirSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { placeStagedFile, listStagedFiles, readStagedSlug, nextFreeSlug } from './data-placement'
+
+let root: string
+let dataDir: string
+let stagingDir: string
+let trashDir: string
+
+const STAMP = '2026-07-26T00-00-00-000Z'
+
+/** Write a staged file the way the CLI would, and return its path. */
+const stage = (filename: string, content: unknown) => {
+  const p = path.join(stagingDir, filename)
+  writeFileSync(p, typeof content === 'string' ? content : JSON.stringify(content, null, 2), 'utf-8')
+  return p
+}
+
+const topic = (slug: string, extra: Record<string, unknown> = {}) => ({
+  meta: { topic: `Topic ${slug}`, slug },
+  overview: { summary: 'body' },
+  ...extra,
+})
+
+const readData = (slug: string) =>
+  JSON.parse(readFileSync(path.join(dataDir, `${slug}.json`), 'utf-8'))
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), 'wd-place-'))
+  dataDir = path.join(root, 'public', 'data')
+  stagingDir = path.join(root, '.claude', 'tmp', 'staging', 'job-1')
+  trashDir = path.join(root, '.claude', 'trash')
+  mkdirSync(dataDir, { recursive: true })
+  mkdirSync(stagingDir, { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+describe('listStagedFiles', () => {
+  it('returns the json files a job staged', () => {
+    stage('a.json', topic('a'))
+    stage('notes.txt', 'ignored')
+    expect(listStagedFiles(stagingDir).map((f) => path.basename(f))).toEqual(['a.json'])
+  })
+
+  it('returns nothing when the job wrote elsewhere', () => {
+    expect(listStagedFiles(path.join(root, 'nope'))).toEqual([])
+  })
+})
+
+describe('readStagedSlug', () => {
+  it('prefers meta.slug over the filename', () => {
+    expect(readStagedSlug(stage('whatever.json', topic('quantum-computing')))).toBe('quantum-computing')
+  })
+
+  it('falls back to the filename when meta.slug is missing or unsafe', () => {
+    expect(readStagedSlug(stage('fallback.json', { meta: { topic: 't' } }))).toBe('fallback')
+    expect(readStagedSlug(stage('safe.json', { meta: { slug: '../../etc/passwd' } }))).toBe('safe')
+  })
+
+  it('falls back to the filename when the JSON does not parse', () => {
+    expect(readStagedSlug(stage('broken.json', '{"meta":{"slug":"broken'))).toBe('broken')
+  })
+})
+
+describe('nextFreeSlug', () => {
+  it('returns the slug itself when nothing occupies it', () => {
+    expect(nextFreeSlug(dataDir, 'webassembly')).toBe('webassembly')
+  })
+
+  it('counts up past every taken suffix', () => {
+    for (const s of ['webassembly', 'webassembly-2', 'webassembly-3']) {
+      writeFileSync(path.join(dataDir, `${s}.json`), '{}', 'utf-8')
+    }
+    expect(nextFreeSlug(dataDir, 'webassembly')).toBe('webassembly-4')
+  })
+})
+
+describe('placeStagedFile - fresh research', () => {
+  it('places the file at its own slug when there is no collision', () => {
+    const staged = stage('quantum.json', topic('quantum'))
+    const result = placeStagedFile({ stagedPath: staged, dataDir, trashDir, stamp: STAMP })
+
+    expect(result.slug).toBe('quantum')
+    expect(result.collidedWith).toBeUndefined()
+    expect(readData('quantum').meta.topic).toBe('Topic quantum')
+    expect(existsSync(staged)).toBe(false)
+  })
+
+  // The #42 regression: a fresh research job that lands on an existing slug
+  // used to overwrite it, losing the topic and its version history for good.
+  it('never touches the existing topic on a collision', () => {
+    const existing = { meta: { topic: 'WebAssembly', slug: 'webassembly' }, versions: [1, 2, 3] }
+    writeFileSync(path.join(dataDir, 'webassembly.json'), JSON.stringify(existing), 'utf-8')
+
+    const staged = stage('webassembly.json', topic('webassembly'))
+    const result = placeStagedFile({ stagedPath: staged, dataDir, trashDir, stamp: STAMP })
+
+    expect(result.slug).toBe('webassembly-2')
+    expect(result.collidedWith).toBe('webassembly')
+    expect(readData('webassembly')).toEqual(existing)
+    expect(readData('webassembly-2').meta.topic).toBe('Topic webassembly')
+  })
+
+  it('rewrites meta.slug so it agrees with where the file landed', () => {
+    writeFileSync(path.join(dataDir, 'react.json'), '{}', 'utf-8')
+    const staged = stage('react.json', topic('react'))
+
+    const result = placeStagedFile({ stagedPath: staged, dataDir, trashDir, stamp: STAMP })
+
+    expect(result.slug).toBe('react-2')
+    expect(readData('react-2').meta.slug).toBe('react-2')
+  })
+
+  it('places a file that does not parse, so the repair action can reach it', () => {
+    const staged = stage('cut-off.json', '{"meta":{"slug":"cut-off"},"overview":')
+
+    const result = placeStagedFile({ stagedPath: staged, dataDir, trashDir, stamp: STAMP })
+
+    expect(result.slug).toBe('cut-off')
+    expect(readFileSync(result.path, 'utf-8')).toBe('{"meta":{"slug":"cut-off"},"overview":')
+  })
+
+  it('refuses a staged file with no usable slug anywhere', () => {
+    const staged = stage('..json', { meta: { slug: '../escape' } })
+    expect(() => placeStagedFile({ stagedPath: staged, dataDir, trashDir, stamp: STAMP }))
+      .toThrow(/no usable slug/)
+  })
+
+  it('does not let meta.slug escape the data directory', () => {
+    const staged = stage('safe.json', { meta: { topic: 't', slug: '../../evil' } })
+
+    const result = placeStagedFile({ stagedPath: staged, dataDir, trashDir, stamp: STAMP })
+
+    expect(result.slug).toBe('safe')
+    expect(path.dirname(result.path)).toBe(dataDir)
+    expect(existsSync(path.join(root, 'evil.json'))).toBe(false)
+  })
+})
+
+describe('placeStagedFile - update and translate', () => {
+  it('overwrites its own slug, keeping a copy of what was there', () => {
+    const before = { meta: { topic: 'React', slug: 'react' }, versions: [1] }
+    writeFileSync(path.join(dataDir, 'react.json'), JSON.stringify(before), 'utf-8')
+    const staged = stage('react.json', topic('react', { versions: [1, 2] }))
+
+    const result = placeStagedFile({
+      stagedPath: staged, dataDir, trashDir, expectedSlug: 'react', stamp: STAMP,
+    })
+
+    expect(result.slug).toBe('react')
+    expect(result.collidedWith).toBeUndefined()
+    expect(readData('react').versions).toEqual([1, 2])
+    expect(JSON.parse(readFileSync(result.backup as string, 'utf-8'))).toEqual(before)
+    expect(readdirSync(trashDir)).toEqual([`react-${STAMP}.json`])
+  })
+
+  it('takes no backup when the target does not exist yet', () => {
+    const staged = stage('react-en.json', topic('react-en'))
+
+    const result = placeStagedFile({
+      stagedPath: staged, dataDir, trashDir, expectedSlug: 'react-en', stamp: STAMP,
+    })
+
+    expect(result.backup).toBeUndefined()
+    expect(existsSync(trashDir)).toBe(false)
+  })
+
+  it('lands on the expected slug even when the CLI wrote a different one', () => {
+    const staged = stage('wrong.json', topic('wrong'))
+
+    const result = placeStagedFile({
+      stagedPath: staged, dataDir, trashDir, expectedSlug: 'react-fr', stamp: STAMP,
+    })
+
+    expect(result.slug).toBe('react-fr')
+    expect(readData('react-fr').meta.slug).toBe('react-fr')
+    expect(existsSync(path.join(dataDir, 'wrong.json'))).toBe(false)
+  })
+})

--- a/server/data-placement.ts
+++ b/server/data-placement.ts
@@ -1,0 +1,141 @@
+// Placement of the data file a job produced.
+//
+// The Claude CLI writes into a per-job staging directory, never straight into
+// public/data. The move is the server's job, and it is the only point where a
+// slug collision can still be caught: once the CLI has written over
+// public/data/{slug}.json the previous encyclopedia is gone — no backup, no
+// version history, and the files are gitignored so there is nothing to restore
+// from (#42, which cost a real WebAssembly topic).
+//
+// Collision policy:
+//   - fresh research — never touch the existing topic. Park the new one under
+//     the next free {slug}-N and rewrite meta.slug to match.
+//   - update / translate — the job owns that slug, so overwriting is the point.
+//     The previous file is still copied to the trash directory first, because a
+//     regeneration that comes back truncated would otherwise take the version
+//     history with it.
+
+import {
+  readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync, unlinkSync, readdirSync,
+} from 'fs'
+import path from 'path'
+import { isValidSlug } from './slug'
+
+/** How far {slug}-2, {slug}-3 … is chased before giving up. */
+const MAX_SUFFIX = 99
+
+export interface PlacementRequest {
+  /** File the CLI wrote into the staging directory. */
+  stagedPath: string
+  dataDir: string
+  /** Where a file about to be overwritten is copied. */
+  trashDir: string
+  /**
+   * Slug the job must land on (update / translate). Leave undefined for fresh
+   * research, where the CLI picks the slug and collisions are possible.
+   */
+  expectedSlug?: string
+  /** Suffix for the backup filename. Passed in so tests stay deterministic. */
+  stamp: string
+}
+
+export interface Placement {
+  slug: string
+  path: string
+  /** The slug the file asked for, set only when it had to land elsewhere. */
+  collidedWith?: string
+  /** Where the previous file was copied before an intentional overwrite. */
+  backup?: string
+}
+
+/** JSON files a job staged, oldest first. Ignores anything that is not .json. */
+export function listStagedFiles(stagingDir: string): string[] {
+  if (!existsSync(stagingDir)) return []
+  return readdirSync(stagingDir)
+    .filter((f) => f.toLowerCase().endsWith('.json'))
+    .map((f) => path.join(stagingDir, f))
+}
+
+/**
+ * The slug a staged file asks for: meta.slug when it is present and valid,
+ * otherwise the filename. Returns null when neither is usable — the caller
+ * decides whether that is fatal.
+ */
+export function readStagedSlug(stagedPath: string): string | null {
+  try {
+    const parsed = JSON.parse(readFileSync(stagedPath, 'utf-8')) as { meta?: { slug?: unknown } }
+    if (isValidSlug(parsed.meta?.slug)) return parsed.meta.slug
+  } catch {
+    // Unparseable JSON still gets placed — the repair UI can only reach files
+    // that live in public/data. Fall back to the filename.
+  }
+  const fromName = path.basename(stagedPath, '.json')
+  return isValidSlug(fromName) ? fromName : null
+}
+
+/** First of {slug}, {slug}-2, {slug}-3 … with no file in dataDir. */
+export function nextFreeSlug(dataDir: string, slug: string): string {
+  if (!existsSync(path.join(dataDir, `${slug}.json`))) return slug
+  for (let n = 2; n <= MAX_SUFFIX; n++) {
+    const candidate = `${slug}-${n}`
+    if (!existsSync(path.join(dataDir, `${candidate}.json`))) return candidate
+  }
+  throw new Error(`No free slug for "${slug}" after ${MAX_SUFFIX} attempts`)
+}
+
+/** Copy a file about to be overwritten into trashDir. Returns the copy's path. */
+function backup(target: string, trashDir: string, slug: string, stamp: string): string {
+  mkdirSync(trashDir, { recursive: true })
+  const dest = path.join(trashDir, `${slug}-${stamp}.json`)
+  copyFileSync(target, dest)
+  return dest
+}
+
+/**
+ * Move the staged file to target, making meta.slug agree with the filename.
+ * Content that does not parse is copied verbatim so the repair action still
+ * has something to work on.
+ */
+function moveInto(stagedPath: string, target: string, slug: string): void {
+  const raw = readFileSync(stagedPath, 'utf-8')
+  let out = raw
+  try {
+    const parsed = JSON.parse(raw) as { meta?: Record<string, unknown> }
+    if (parsed.meta && parsed.meta.slug !== slug) {
+      parsed.meta.slug = slug
+      out = JSON.stringify(parsed, null, 2)
+    }
+  } catch {
+    // Leave the bytes alone.
+  }
+  if (out === raw) copyFileSync(stagedPath, target)
+  else writeFileSync(target, out, 'utf-8')
+  unlinkSync(stagedPath)
+}
+
+export function placeStagedFile(req: PlacementRequest): Placement {
+  const { stagedPath, dataDir, trashDir, expectedSlug, stamp } = req
+
+  const requested = expectedSlug ?? readStagedSlug(stagedPath)
+  if (!isValidSlug(requested)) {
+    throw new Error(`Staged file has no usable slug: ${path.basename(stagedPath)}`)
+  }
+
+  mkdirSync(dataDir, { recursive: true })
+
+  if (expectedSlug) {
+    const target = path.join(dataDir, `${expectedSlug}.json`)
+    const saved = existsSync(target) ? backup(target, trashDir, expectedSlug, stamp) : undefined
+    moveInto(stagedPath, target, expectedSlug)
+    return { slug: expectedSlug, path: target, backup: saved }
+  }
+
+  const free = nextFreeSlug(dataDir, requested)
+  const target = path.join(dataDir, `${free}.json`)
+  moveInto(stagedPath, target, free)
+  return {
+    slug: free,
+    path: target,
+    collidedWith: free === requested ? undefined : requested,
+  }
+}

--- a/server/research-api.ts
+++ b/server/research-api.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from 'vite'
 import { spawn } from 'child_process'
-import { readFileSync, writeFileSync, mkdirSync, existsSync, unlinkSync } from 'fs'
+import { readFileSync, writeFileSync, mkdirSync, existsSync, unlinkSync, rmSync } from 'fs'
 import path from 'path'
 import { log as slog } from './job-logger'
 import { updateIndex, removeFromIndex } from './index-writer'
@@ -9,6 +9,7 @@ import {
 } from './job-store'
 import { isValidSlug, resolveDataPath } from './slug'
 import { repairJsonFile, repairJsonString } from './json-repair'
+import { listStagedFiles, placeStagedFile } from './data-placement'
 
 interface LogEntry {
   timestamp: string;
@@ -30,6 +31,10 @@ interface ResearchJob {
   // Pre-known slug for translate/update modes; for fresh research it's
   // derived from writtenFiles when the job completes.
   slug?: string;
+  // Per-job directory the CLI writes into. The server moves the result into
+  // public/data itself so a slug collision can be caught before it destroys
+  // an existing topic (#42). Absent for jobs restored from before this existed.
+  stagingDir?: string;
 }
 
 const LOG_MESSAGES: Record<string, Record<string, string>> = {
@@ -138,6 +143,12 @@ function addLog(job: ResearchJob, phase: LogEntry['phase'], message: string) {
   persistJobDebounced(job.jobId, job);
 }
 
+/** True when child resolves to a path inside dir. Tolerates mixed separators. */
+function isInside(dir: string, child: string): boolean {
+  const rel = path.relative(path.resolve(dir), path.resolve(child));
+  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+
 /** Read meta.topic from a written data file. Falls back to null if missing. */
 function readTopicFromDataFile(slug: string): string | null {
   try {
@@ -224,6 +235,83 @@ function validateAndRepairJson(filePath: string): { valid: boolean; repaired?: b
   return { valid: result.valid, repaired: result.repaired, error: result.error };
 }
 
+function validateAndRepairLogged(job: ResearchJob, filePath: string): void {
+  const { valid, repaired, error: jsonErr } = validateAndRepairJson(filePath);
+  const filename = path.basename(filePath);
+  if (repaired) {
+    addLog(job, 'writing', `JSON自動修復: ${filename}`);
+  } else if (!valid) {
+    addLog(job, 'error', `JSONバリデーションエラー (${filename}): ${jsonErr}`);
+  }
+}
+
+/**
+ * Move what the job staged into public/data, then point writtenFiles at the
+ * final locations so resolveSlug() and the index update see them.
+ *
+ * Runs before finalizeJob. A job whose CLI ignored the staging instruction and
+ * wrote straight into public/data keeps its original writtenFiles — by then
+ * there is nothing left to protect, so the only useful thing is a loud log.
+ */
+function placeJobOutput(job: ResearchJob, stagingDir: string, dataDir: string): void {
+  const staged = listStagedFiles(stagingDir);
+
+  if (staged.length === 0) {
+    if (job.writtenFiles.length > 0) {
+      slog('warn', 'job.no_staged_output', {
+        jobId: job.jobId, stagingDir, writtenFiles: job.writtenFiles,
+      });
+    }
+    // A Write the CLI announced is not a Write that happened — it can be
+    // denied, and then the path exists only in the event stream. Keeping it
+    // would let resolveSlug() name a file nobody wrote and stamp the matching
+    // index entry as updated.
+    job.writtenFiles = job.writtenFiles.filter((fp) => existsSync(fp));
+    for (const fp of job.writtenFiles) validateAndRepairLogged(job, fp);
+    return;
+  }
+
+  const trashDir = path.join(process.cwd(), '.claude', 'trash');
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const placed: string[] = [];
+
+  for (const stagedPath of staged) {
+    validateAndRepairLogged(job, stagedPath);
+    try {
+      // Fresh research lets the CLI choose the slug, so it may collide. Update
+      // and translate own their slug and overwrite it on purpose.
+      const result = placeStagedFile({
+        stagedPath,
+        dataDir,
+        trashDir,
+        expectedSlug: job.mode === 'research' ? undefined : job.slug,
+        stamp,
+      });
+      placed.push(result.path);
+
+      if (result.collidedWith) {
+        slog('warn', 'job.slug_collision', {
+          jobId: job.jobId, requested: result.collidedWith, savedAs: result.slug,
+        });
+        addLog(job, 'writing',
+          `slug「${result.collidedWith}」は既存の辞典が使用中のため、「${result.slug}」として保存しました`);
+      }
+      if (result.backup) {
+        slog('info', 'job.backup_before_overwrite', {
+          jobId: job.jobId, slug: result.slug, backup: result.backup,
+        });
+      }
+    } catch (e) {
+      const errMsg = e instanceof Error ? e.message : String(e);
+      slog('error', 'job.place_failed', { jobId: job.jobId, stagedPath, error: errMsg });
+      addLog(job, 'error', `データファイルの配置に失敗しました: ${errMsg}`);
+    }
+  }
+
+  if (placed.length > 0) job.writtenFiles = placed;
+  rmSync(stagingDir, { recursive: true, force: true });
+}
+
 function markDone(job: ResearchJob) {
   if (!job.completedAt) job.completedAt = new Date().toISOString();
 }
@@ -262,6 +350,16 @@ function parseStreamLine(line: string, job: ResearchJob) {
             }
           } else if (toolName === 'Write') {
             const filePath: string = input.file_path ?? '';
+            // Everything the job writes belongs in its staging directory so
+            // the server controls placement (#42). Checked for every write,
+            // not just .json: a CLI whose destination is denied improvises,
+            // and one run left a 34KB .mjs at the repo root that would have
+            // written the data file itself.
+            if (job.stagingDir && filePath && !isInside(job.stagingDir, filePath)) {
+              slog('warn', 'cli.wrote_outside_staging', {
+                jobId: job.jobId, filePath, stagingDir: job.stagingDir,
+              });
+            }
             if (filePath.includes('index.json')) {
               // The CLI is now instructed not to touch index.json. If we see
               // this, the prompt failed — log it so we can tighten the prompt
@@ -632,6 +730,11 @@ export function researchApiPlugin(): Plugin {
 
             const newSlug = `${sourceSlug}-${targetLang}`;
             const jobId = newJobPrefix() + '-' + Date.now();
+            // Same staging rule as research (#42). A re-translation overwrites
+            // its own slug on purpose, but only after the previous file has
+            // been copied aside and the new one has been checked.
+            const stagingDir = path.join(projectRoot, '.staging', jobId);
+            mkdirSync(stagingDir, { recursive: true });
 
             const LANG_NAMES: Record<string, string> = {
               ja: 'Japanese', en: 'English', zh: 'Chinese (Simplified)',
@@ -649,6 +752,7 @@ export function researchApiPlugin(): Plugin {
               writtenFiles: [],
               mode: 'translate',
               slug: newSlug,
+              stagingDir,
             };
             jobs.set(jobId, job);
             addLog(job, 'start', `${msg(targetLang, 'start')}: ${sourceTopic} → ${targetLangName}`);
@@ -714,7 +818,10 @@ export function researchApiPlugin(): Plugin {
               '',
               skillInstructions,
               '',
-              `IMPORTANT: Write output files to ${dataDir.replace(/\\/g, '/')}`,
+              // Overrides the skill text, which says to write into public/data
+              // (#42) — the server moves the file there after checking it.
+              `IMPORTANT: Write output files to ${stagingDir.replace(/\\/g, '/')}`,
+              'IMPORTANT: Ignore any instruction above to write into public/data. Write the single data file into the directory named on the previous line. The server moves it into public/data once it has been checked.',
               `Output slug must be "${newSlug}"`,
               'IMPORTANT: Only write the single data file. Do not touch index.json.',
             ].join('\n');
@@ -773,17 +880,8 @@ export function researchApiPlugin(): Plugin {
                   addLog(job, 'error', job.message);
                 }
               }
-              // Validate written JSON files after translation completes
-              if (job.status === 'completed' && job.writtenFiles.length > 0) {
-                for (const fp of job.writtenFiles) {
-                  const { valid, repaired, error: jsonErr } = validateAndRepairJson(fp);
-                  const filename = path.basename(fp);
-                  if (repaired) {
-                    addLog(job, 'writing', `JSON自動修復: ${filename}`);
-                  } else if (!valid) {
-                    addLog(job, 'error', `JSONバリデーションエラー (${filename}): ${jsonErr}`);
-                  }
-                }
+              if (job.status === 'completed') {
+                placeJobOutput(job, stagingDir, dataDir);
               }
               void finalizeJob(job, { code, signal, reason: 'subprocess close' });
             });
@@ -830,11 +928,12 @@ export function researchApiPlugin(): Plugin {
             res.end(JSON.stringify({ error: 'Job not found' }));
             return;
           }
-          // Strip writtenFiles + jobId (jobId is the response key already)
-          // and re-derive slug from the last written data file as a fallback
-          // for jobs that didn't pre-set job.slug.
-          const { writtenFiles, jobId: _omit, ...jobData } = job;
+          // Strip server-side bookkeeping (writtenFiles, stagingDir) and jobId
+          // (jobId is the response key already), then re-derive slug from the
+          // last written data file for jobs that didn't pre-set job.slug.
+          const { writtenFiles, jobId: _omit, stagingDir: _staging, ...jobData } = job;
           void _omit;
+          void _staging;
           const dataFiles = writtenFiles.filter(f => !f.includes('index.json') && f.endsWith('.json'));
           const derived = dataFiles.length > 0 ? path.basename(dataFiles[dataFiles.length - 1], '.json') : undefined;
           res.end(JSON.stringify({ jobId, ...jobData, slug: jobData.slug ?? derived }));
@@ -844,10 +943,11 @@ export function researchApiPlugin(): Plugin {
         // GET /api/research — list all jobs
         if (req.method === 'GET' && url.match(/^\/api\/research\/?(\?.*)?$/)) {
           pruneOldJobs();
-          const all: Record<string, Omit<ResearchJob, 'writtenFiles' | 'jobId'> & { slug?: string }> = {};
+          const all: Record<string, Omit<ResearchJob, 'writtenFiles' | 'jobId' | 'stagingDir'> & { slug?: string }> = {};
           for (const [id, j] of jobs) {
-            const { writtenFiles, jobId: _omit, ...jData } = j;
+            const { writtenFiles, jobId: _omit, stagingDir: _staging, ...jData } = j;
             void _omit;
+            void _staging;
             const dataFiles = writtenFiles.filter(f => !f.includes('index.json') && f.endsWith('.json'));
             const derived = dataFiles.length > 0 ? path.basename(dataFiles[dataFiles.length - 1], '.json') : undefined;
             all[id] = { ...jData, slug: jData.slug ?? derived };
@@ -890,6 +990,16 @@ export function researchApiPlugin(): Plugin {
                 return;
               }
 
+              const projectRoot = process.cwd();
+              // The CLI writes here, not into public/data. finalizeJob does the
+              // move, which is the only place a slug collision can still be
+              // caught before it overwrites an existing topic (#42).
+              // Not under .claude/ — the CLI refuses to write there
+              // ("sensitive file"), which leaves the job retrying until it
+              // runs out of turns.
+              const stagingDir = path.join(projectRoot, '.staging', jobId);
+              mkdirSync(stagingDir, { recursive: true });
+
               const job: ResearchJob = {
                 jobId,
                 topic,
@@ -900,6 +1010,7 @@ export function researchApiPlugin(): Plugin {
                 writtenFiles: [],
                 mode: isUpdate ? 'update' : 'research',
                 slug: isUpdate ? existingSlug : undefined,
+                stagingDir,
               };
               jobs.set(jobId, job);
 
@@ -910,8 +1021,6 @@ export function researchApiPlugin(): Plugin {
                 existingSlug: isUpdate ? existingSlug : null,
                 concurrentRunning: running.length + 1,
               });
-
-              const projectRoot = process.cwd();
 
               // Write prompt to a temp file to avoid shell escaping issues
               const tmpDir = path.join(projectRoot, '.claude', 'tmp');
@@ -1003,8 +1112,11 @@ export function researchApiPlugin(): Plugin {
                 '',
                 skillInstructions,
                 '',
-                `IMPORTANT: Write output files to ${dataDir}`,
-                'IMPORTANT: Only write the single ${slug}.json data file. Do not touch index.json.',
+                // Overrides the skill text, which says to write into
+                // public/data. The server moves the file there itself so that
+                // a slug collision cannot destroy an existing topic (#42).
+                `IMPORTANT: Write output files to ${stagingDir.replace(/\\/g, '/')}`,
+                'IMPORTANT: Ignore any instruction above to write into public/data. Write the single ${slug}.json file into the directory named on the previous line and nothing else. The server moves it into public/data once it has been checked.',
                 `REMINDER: Write all content in ${langName}.`,
               ].join('\n');
 
@@ -1071,17 +1183,8 @@ export function researchApiPlugin(): Plugin {
                     addLog(job, 'error', job.message);
                   }
                 }
-                // Validate only the JSON files written by this job
-                if (job.status === 'completed' && job.writtenFiles.length > 0) {
-                  for (const fp of job.writtenFiles) {
-                    const { valid, repaired, error: jsonErr } = validateAndRepairJson(fp);
-                    const filename = path.basename(fp);
-                    if (repaired) {
-                      addLog(job, 'writing', `JSON自動修復: ${filename}`);
-                    } else if (!valid) {
-                      addLog(job, 'error', `JSONバリデーションエラー (${filename}): ${jsonErr}`);
-                    }
-                  }
+                if (job.status === 'completed') {
+                  placeJobOutput(job, stagingDir, path.join(projectRoot, 'public', 'data'));
                 }
                 void finalizeJob(job, { code, signal, reason: 'subprocess close' });
               });


### PR DESCRIPTION
Closes #42

## なぜ finalizeJob での検出では直らないか

`public/data/{slug}.json` を書くのは CLI サブプロセス自身なので、`finalizeJob` が動く時点で既存の辞典はもう消えている。バックアップも versions 履歴も残らず、データファイルは gitignore なので git からも復元できない（#27 の検証中に WebAssembly 辞典を1件失ったのがこれ）。

そこで **CLI の出力先を `.staging/{jobId}/` に変え、`public/data/` への配置はサーバが行う**ようにした。`index.json` を既にサーバが所有しているのと同じ形。

## 衝突ポリシー（`server/data-placement.ts`）

| モード | 挙動 |
|---|---|
| 新規調査 | 既存には触れず、空いている `{slug}-2` に置く。`meta.slug` も書き換える |
| 更新 / 翻訳 | slug はジョブが所有しているので上書きしてよい。ただし直前に `.claude/trash/{slug}-{timestamp}.json` へ退避 |
| パース不能な JSON | それでも配置する。修復 UI は `public/data` のファイルしか触れないため |

ルートに何も確定していない場合など配置できないケースは `job.place_failed` で warn。

## 実装上の落とし穴（ハマったので記録）

- **ステージングを `.claude/` 配下に置けない。** Claude Code が sensitive file として Write を拒否し、ジョブがターン上限までリトライし続ける。実際に1本潰した
- そのとき CLI は**代替手段を自作する**。拒否されたジョブは 34KB の `.mjs` をリポジトリ直下に書き、そこからデータファイルを書こうとしていた（Bash が allowedTools に無いので未実行）。このため `cli.wrote_outside_staging` は `.json` に限らず全ての Write を対象にした
- Write の tool_use イベントは「書いた」ではなく「書こうとした」でしかない。拒否されると `writtenFiles` に実在しないパスが残り、そこから derive した slug で index の `updatedAt` だけが更新されてしまうため、存在しないパスは落とすようにした

## 検証（実 CLI ジョブ）

1. **衝突** — `WebAssembly` を再度新規調査 → `webassembly.json` は 39821 バイト・sha256 完全一致のまま、`webassembly-2` が新規作成。`job.slug_collision {"requested":"webassembly","savedAs":"webassembly-2"}` を記録
2. **翻訳（初回）** — `omura-city` → it。`.staging` 経由で配置、退避なし
3. **翻訳（再実行）** — 上書き前に `.claude/trash/omura-city-it-2026-07-26T11-54-16-607Z.json` へ退避。退避コピーの sha256 が上書き前のファイルと一致
4. ステージングディレクトリは配置後に削除されることを確認

ユニットテスト16件を追加（衝突・meta.slug 書き換え・退避・traversal 拒否・パース不能ファイルの配置）。`tsc -b` / `eslint .` / `vitest run`（79件）すべて通過。

## 残った検証用データ

`webassembly-2` と `omura-city-it` は検証で生成された実データ。内容は正常なので残してあるが、不要なら UI から削除してよい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
